### PR TITLE
Change method name 'analyze' to 'loadDir', 'analyze' to 'loadFile', 'serialize' to 'saveToCache'

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="12" project-jdk-type="JavaSDK" />
+</project>

--- a/yin/rubysonar-master/src/main/java/org/yinwang/rubysonar/Analyzer.java
+++ b/yin/rubysonar-master/src/main/java/org/yinwang/rubysonar/Analyzer.java
@@ -114,7 +114,7 @@ public class Analyzer {
 
 
     // main entry to the analyzer (for JSONDump only)
-    public void analyze(List<String> paths) {
+    public void loadFile(List<String> paths) {
         for (String path : paths) {
             loadFileRecursive(path);
         }

--- a/yin/rubysonar-master/src/main/java/org/yinwang/rubysonar/Analyzer.java
+++ b/yin/rubysonar-master/src/main/java/org/yinwang/rubysonar/Analyzer.java
@@ -105,7 +105,7 @@ public class Analyzer {
 
 
     // main entry to the analyzer
-    public void analyze(String path) {
+    public void loadDir(String path) {
         String upath = _.unifyPath(path);
         File f = new File(upath);
         projectDir = f.isDirectory() ? f.getPath() : f.getParent();

--- a/yin/rubysonar-master/src/main/java/org/yinwang/rubysonar/AstCache.java
+++ b/yin/rubysonar-master/src/main/java/org/yinwang/rubysonar/AstCache.java
@@ -102,7 +102,7 @@ public class AstCache {
         }
 
         if (node != null) {
-            serialize(node);
+            saveToCache(node);
         }
 
         return node;
@@ -127,7 +127,7 @@ public class AstCache {
 
 
     // package-private for testing
-    void serialize(@NotNull Node ast) {
+    void saveToCache(@NotNull Node ast) {
         String path = getCachePath(_.getSHA(ast.file), new File(ast.file).getName());
         ObjectOutputStream oos = null;
         FileOutputStream fos = null;


### PR DESCRIPTION
The class Analyzer is used to represent Analyzer.  This method named 'analyze' is to load a directory. Thus, the method name 'loadDir' is more intuitive than 'analyze'.

The class Analyzer is used to represent Analyzer.  This method named 'analyze' is to load a file. Thus, the method name 'loadFile' is more intuitive than 'analyze'.

The class AstCache is used to represent AstCache.  This method named 'serialize' is to save to the cache. Thus, the method name 'saveToCache' is more intuitive than 'serialize'.